### PR TITLE
Adição de estratégia para limpeza do db após testes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development, :test do
   gem 'spring-commands-rspec'
   gem 'guard-rspec', '~> 4.7', '>= 4.7.3'
   gem 'capybara'
+  gem 'database_cleaner'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     devise (4.2.0)
       bcrypt (~> 3.0)
@@ -332,6 +333,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
+  database_cleaner
   devise
   devise-i18n
   factory_girl_rails (~> 4.7.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -66,4 +66,30 @@ RSpec.configure do |config|
 
   # Add warden method like 'login_as' to use in integration tests.
   config.include Warden::Test::Helpers
+
+  # Before the entire test suit runs, clear out the database.
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  # Set default strategy.
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  # For tests flagged with ':js => true', transaction strategy doesn't work.
+  # So set strategy to truncation.
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  # Start database cleaner strategy before each test.
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  # Clean the database after each test.
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 end


### PR DESCRIPTION
Este pull-request contém:

- Adição da gem database_cleaner (utilizada nos testes);
- Configuração de uma estratégia, utilizando o database_cleaner, para limpeza do banco entre testes (útil para evitar erros aleatórios nos testes).